### PR TITLE
fixed image reference

### DIFF
--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -1,6 +1,6 @@
 services:
   gcv:
-    image: ghcr.io/legumeinfo/microservices-chromosome:2.2.0
+    image: ghcr.io/legumeinfo/gcv:2.2.0
     ports:
       - "4200:80"
     restart: always


### PR DESCRIPTION
surely compose.prod.yml meant to specify the gcv:2.2.0 image instead of microservices-chromosome:2.2.0