### PR TITLE
Add redis_loader service

### DIFF
--- a/microservices/compose.prod.yml
+++ b/microservices/compose.prod.yml
@@ -223,3 +223,12 @@ services:
       - "traefik.http.middlewares.search-stripprefix.stripprefix.prefixes=/gcv/microservices/search"
       - "traefik.http.routers.search.middlewares=search-stripprefix@docker"
       - "traefik.http.routers.search.entrypoints=web"
+
+  redis_loader:
+    image: ghcr.io/legumeinfo/microservices-redis_loader:1.0.0
+    depends_on:
+      redisearch:
+        condition: service_healthy
+    environment:
+      REDIS_HOST: redisearch
+    profiles: [redis_loader]

--- a/microservices/compose.yml
+++ b/microservices/compose.yml
@@ -214,3 +214,12 @@ services:
       - "traefik.http.middlewares.search-stripprefix.stripprefix.prefixes=/gcv/microservices/search"
       - "traefik.http.routers.search.middlewares=search-stripprefix@docker"
       - "traefik.http.routers.search.entrypoints=web"
+
+  redis_loader:
+    image: ghcr.io/legumeinfo/microservices-redis_loader:1.0.0
+    depends_on:
+      redisearch:
+        condition: service_healthy
+    environment:
+      REDIS_HOST: redisearch
+    profiles: [redis_loader]


### PR DESCRIPTION
Allows loading `redisearch` DB with relatively simple `docker compose` commands; e.g.:

```
docker compose -f microservices/compose.yml run --use-aliases redis_loader ...
```