### PR TITLE
Disable redis snapshots & robustify health check

### DIFF
--- a/microservices/compose.prod.yml
+++ b/microservices/compose.prod.yml
@@ -33,13 +33,17 @@ services:
       - "traefik.http.routers.envoy.entrypoints=web"
 
   redisearch:
-    image: redislabs/redisearch:2.0.5
+    image: redislabs/redisearch:2.0.15
     healthcheck:
-      test: "redis-cli ping"
+      test: "redis-cli ping | grep -q PONG"
     expose:
       - "6379"
     volumes:
       - ./data/redis:/data:rw
+    command:
+      - --loadmodule /usr/lib/redis/modules/redisearch.so
+      - --save ''
+      
 
   chromosome:
     image: ghcr.io/legumeinfo/microservices-chromosome:1.0.0

--- a/microservices/compose.yml
+++ b/microservices/compose.yml
@@ -30,13 +30,16 @@ services:
       - "traefik.http.routers.envoy.entrypoints=web"
 
   redisearch:
-    image: redislabs/redisearch:2.0.9
+    image: redislabs/redisearch:2.0.15
     healthcheck:
-      test: "redis-cli ping"
+      test: "redis-cli ping | grep -q PONG"
     expose:
       - "6379"
     volumes:
       - ./data/redis:/data:rw
+    command:
+      - --loadmodule /usr/lib/redis/modules/redisearch.so
+      - --save ''
 
   chromosome:
     image: ghcr.io/legumeinfo/microservices-chromosome:1.0.0


### PR DESCRIPTION
This PR:

1. Makes redisearch service health checks more reliable by explicitly checking for a `redis-cli ping` response of "PONG", as the command returns an exit status of 0 when it can connect to redis, but a dump.rdb snapshot is still loading:

```
# redis-cli ping
(error) LOADING Redis is loading the dataset in memory
# echo $?
0
```

2. Disables automatic background redis snapshots to address #414 