### PR TITLE
Change the default macro-synteny ordering to 'distance'

### DIFF
--- a/src/app/core/services/app-config.service.ts
+++ b/src/app/core/services/app-config.service.ts
@@ -44,7 +44,7 @@ const defaultConfig = {
         intermediate: 10,
         mask: 10,
       },
-      macroSyntenyOrder: 'chromosome',
+      macroSyntenyOrder: 'distance',
       microSynteny: {
         neighbors: 10,
         matched: 4,


### PR DESCRIPTION
Updated gcv/src/app/core/services/app-config.service.ts  macroSyntenyOrder from chromosome to distance