### PR TITLE
Help dropdown header navbar item

### DIFF
--- a/src/app/core/components/header.component.html
+++ b/src/app/core/components/header.component.html
@@ -20,6 +20,22 @@
           <gcv-expand-search-widget></gcv-expand-search-widget>
         </div>
         <div class="navbar-right">
+          <ul class="navbar-nav me-auto">
+            <li class="nav-item dropdown">
+              <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                Help
+              </a>
+              <div class="dropdown-menu dropdown-menu-end" aria-labelledby="dropdownMenuLink">
+                <a class="dropdown-item" [routerLink]="['/instructions']" target="_blank">Instructions</a>
+                <a class="dropdown-item" href="https://github.com/legumeinfo/lis_context_viewer/wiki" target="_blank">Documentation</a>
+                <a class="dropdown-item" href="https://doi.org/10.1093/bioinformatics/btx757" target="_blank">Manuscript</a>
+                <div class="dropdown-divider"></div>
+                <a class="dropdown-item" href="https://github.com/legumeinfo/lis_context_viewer/issues" target="_blank">Contact developers</a>
+              </div>
+            </li>
+          </ul>
+        </div>
+        <div class="navbar-right">
           <router-outlet name="header-right"></router-outlet>
           <ng-content select="[right]"></ng-content>
         </div>

--- a/src/app/gene/components/header/header-right.component.ts
+++ b/src/app/gene/components/header/header-right.component.ts
@@ -21,18 +21,6 @@ import { InterAppCommunicationService } from '@gcv/gene/services';
           <gcv-inter-app-communication></gcv-inter-app-communication>
         </div>
       </li>
-      <li class="nav-item dropdown">
-        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-          Help
-        </a>
-        <div class="dropdown-menu dropdown-menu-end" aria-labelledby="dropdownMenuLink">
-          <a class="dropdown-item" [routerLink]="['/instructions']" target="_blank">Instructions</a>
-          <a class="dropdown-item" href="https://github.com/legumeinfo/lis_context_viewer/wiki" target="_blank">Documentation</a>
-          <a class="dropdown-item" href="https://doi.org/10.1093/bioinformatics/btx757" target="_blank">Manuscript</a>
-          <div class="dropdown-divider"></div>
-          <a class="dropdown-item" href="https://github.com/legumeinfo/lis_context_viewer/issues" target="_blank">Contact developers</a>
-        </div>
-      </li>
     </ul>
   `,
 })


### PR DESCRIPTION
Moved the help dropdown from the header navbar in the gene module to header navbar in the core module so it appears on every page in the app.