### PR TITLE
Search widget text

### DIFF
--- a/src/app/widgets/components/search/abstract-search-widget.component.ts
+++ b/src/app/widgets/components/search/abstract-search-widget.component.ts
@@ -1,17 +1,23 @@
 // Angular
-import { Component } from '@angular/core';
-import { Router } from '@angular/router';
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Router } from '@angular/router';
+// NgRx
+import { filter, map } from 'rxjs/operators';
 // app
 import { AppConfig, Server } from '@gcv/core/models';
 
 
 @Component({template: ''})
-export class AbstractSearchWidgetComponent {
+export class AbstractSearchWidgetComponent implements OnInit {
 
   model: any;
   sources: Server[];
 
-  constructor(protected _appConfig: AppConfig, protected router: Router) {
+  constructor(
+    protected _appConfig: AppConfig,
+    protected _activatedRoute: ActivatedRoute,
+    protected router: Router,
+  ) {
     this.model = {
       query: '',
       sources: _appConfig.servers
@@ -19,6 +25,15 @@ export class AbstractSearchWidgetComponent {
                  .map((s) => s.id),
     };
     this.sources = _appConfig.servers.filter((s) => s.hasOwnProperty('search'));
+  }
+
+  ngOnInit(): void {
+    this._activatedRoute.queryParams.pipe(
+      filter((queryParams) => 'q' in queryParams),
+      map((queryParams) => queryParams['q']),
+    ).subscribe((query) => {
+      this.model.query = query;
+    });
   }
 
   submit(): void {

--- a/src/app/widgets/components/search/search-widget.component.ts
+++ b/src/app/widgets/components/search/search-widget.component.ts
@@ -1,6 +1,5 @@
 // Angular
 import { Component } from '@angular/core';
-import { Router } from '@angular/router';
 // App
 import { AbstractSearchWidgetComponent }
   from './abstract-search-widget.component';
@@ -13,11 +12,6 @@ import { AppConfig } from '@gcv/core/models';
 })
 export class SearchWidgetComponent extends AbstractSearchWidgetComponent {
 
-  helpText: string;
-
-  constructor(protected _appConfig: AppConfig, protected router: Router) {
-    super(_appConfig, router);
-    this.helpText = _appConfig.miscellaneous.searchHelpText;
-  }
+  helpText: string = AppConfig.miscellaneous.searchHelpText;
 
 }


### PR DESCRIPTION
Updated the search widget to contain the search term in the query string parameters, in any. This causes the search term to be present in the search widget when GCV is loaded from a link or when a navigation event occurs within the app.